### PR TITLE
fix: avoid a stuck when piwik.js return 401 status

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -30,7 +30,7 @@
 		_paq.push(['setTrackerUrl', u+'piwik.php']);
 		_paq.push(['setSiteId', '1']);
 		var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-		g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+		g.type='text/javascript'; g.async=true; g.defer=true; g.src='https://cdn.bootcss.com/piwik/3.5.0-rc1/piwik.js'; s.parentNode.insertBefore(g,s);
 	  })();
 	</script>
 	<noscript><p><img src="//t.ghosts.work/piwik/piwik.php?idsite=1&rec=1" style="border:0;" alt="" /></p></noscript>

--- a/en/links/index.html
+++ b/en/links/index.html
@@ -27,7 +27,7 @@
 		_paq.push(['setTrackerUrl', u+'piwik.php']);
 		_paq.push(['setSiteId', '1']);
 		var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-		g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+		g.type='text/javascript'; g.async=true; g.defer=true; g.src='https://cdn.bootcss.com/piwik/3.5.0-rc1/piwik.js'; s.parentNode.insertBefore(g,s);
 	  })();
 	</script>
 	<noscript><p><img src="//t.ghosts.work/piwik/piwik.php?idsite=1&rec=1" style="border:0;" alt="" /></p></noscript>

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
 		_paq.push(['setTrackerUrl', u+'piwik.php']);
 		_paq.push(['setSiteId', '1']);
 		var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-		g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+		g.type='text/javascript'; g.async=true; g.defer=true; g.src='https://cdn.bootcss.com/piwik/3.5.0-rc1/piwik.js'; s.parentNode.insertBefore(g,s);
 	  })();
 	</script>
 	<noscript><p><img src="//t.ghosts.work/piwik/piwik.php?idsite=1&rec=1" style="border:0;" alt="" /></p></noscript>

--- a/ja_JP/index.html
+++ b/ja_JP/index.html
@@ -30,7 +30,7 @@
 		_paq.push(['setTrackerUrl', u+'piwik.php']);
 		_paq.push(['setSiteId', '1']);
 		var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-		g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+		g.type='text/javascript'; g.async=true; g.defer=true; g.src='https://cdn.bootcss.com/piwik/3.5.0-rc1/piwik.js'; s.parentNode.insertBefore(g,s);
 	  })();
 	</script>
 	<noscript><p><img src="//t.ghosts.work/piwik/piwik.php?idsite=1&rec=1" style="border:0;" alt="" /></p></noscript>

--- a/ja_JP/links/index.html
+++ b/ja_JP/links/index.html
@@ -28,7 +28,7 @@
 		_paq.push(['setTrackerUrl', u+'piwik.php']);
 		_paq.push(['setSiteId', '1']);
 		var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-		g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+		g.type='text/javascript'; g.async=true; g.defer=true; g.src='https://cdn.bootcss.com/piwik/3.5.0-rc1/piwik.js'; s.parentNode.insertBefore(g,s);
 	  })();
 	</script>
 	<noscript><p><img src="//t.ghosts.work/piwik/piwik.php?idsite=1&rec=1" style="border:0;" alt="" /></p></noscript>

--- a/links/index.html
+++ b/links/index.html
@@ -28,7 +28,7 @@
 		_paq.push(['setTrackerUrl', u+'piwik.php']);
 		_paq.push(['setSiteId', '1']);
 		var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-		g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+		g.type='text/javascript'; g.async=true; g.defer=true; g.src='https://cdn.bootcss.com/piwik/3.5.0-rc1/piwik.js'; s.parentNode.insertBefore(g,s);
 	  })();
 	</script>
 	<noscript><p><img src="//t.ghosts.work/piwik/piwik.php?idsite=1&rec=1" style="border:0;" alt="" /></p></noscript>

--- a/zh-TW/index.html
+++ b/zh-TW/index.html
@@ -30,7 +30,7 @@
 		  _paq.push(['setTrackerUrl', u+'piwik.php']);
 		  _paq.push(['setSiteId', '1']);
 		  var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-		  g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+		  g.type='text/javascript'; g.async=true; g.defer=true; g.src='https://cdn.bootcss.com/piwik/3.5.0-rc1/piwik.js'; s.parentNode.insertBefore(g,s);
 		})();
 	  </script>
 	  <noscript><p><img src="//t.ghosts.work/piwik/piwik.php?idsite=1&rec=1" style="border:0;" alt="" /></p></noscript>

--- a/zh-TW/links/index.html
+++ b/zh-TW/links/index.html
@@ -27,7 +27,7 @@
 		  _paq.push(['setTrackerUrl', u+'piwik.php']);
 		  _paq.push(['setSiteId', '1']);
 		  var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-		  g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+		  g.type='text/javascript'; g.async=true; g.defer=true; g.src='https://cdn.bootcss.com/piwik/3.5.0-rc1/piwik.js'; s.parentNode.insertBefore(g,s);
 		})();
 	  </script>
 	  <noscript><p><img src="//t.ghosts.work/piwik/piwik.php?idsite=1&rec=1" style="border:0;" alt="" /></p></noscript>


### PR DESCRIPTION
## 问题：

加载网页时跳转 http://t.ghosts.work/piwik/piwik.js 弹出 401 对话框请求登陆

## 复现方法：

在不屏蔽任何 Analytics Track 域名和 URL 的情况下打开 amazingapps.org

## 原因：

错误配置的 Piwik 使 Piwik.js 返回 401，Chrome 会跟随完成认证以完成页面加载

## 解决方案：

piwik.js 引用公共 CDN 库加载

## 仍然可能存在的问题：

Piwik 服务端 401 设置不当使 piwik.php 无法正常加载，仍然返回 401 并跳转验证
